### PR TITLE
Nikunjr/optimize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ bin-int/
 .vs/
 *.user
 *.dat
+
+# profiling data
+*.vspx

--- a/PlaneverbSandbox/PlaneverbSandbox.vcxproj
+++ b/PlaneverbSandbox/PlaneverbSandbox.vcxproj
@@ -118,6 +118,7 @@ xcopy /y $(SolutionDir)bin\$(Configuration)-$(Platform)\PlaneverbDSP\PlaneverbDS
     </ClCompile>
     <PostBuildEvent>
       <Command>xcopy /y $(SolutionDir)bin\$(Configuration)-$(Platform)\ProjectPlaneverb\ProjectPlaneverb.dll $(SolutionDir)bin\$(Configuration)-$(Platform)\$(ProjectName)
+xcopy /y $(SolutionDir)bin\$(Configuration)-$(Platform)\ProjectPlaneverb\ProjectPlaneverb.pdb $(SolutionDir)bin\$(Configuration)-$(Platform)\$(ProjectName)
 xcopy /y $(SolutionDir)External\dll\$(Platform)\*.dll $(SolutionDir)bin\$(Configuration)-$(Platform)\$(ProjectName)
 xcopy /y $(SolutionDir)bin\$(Configuration)-$(Platform)\PlaneverbDSP\PlaneverbDSP.dll $(SolutionDir)bin\$(Configuration)-$(Platform)\$(ProjectName)</Command>
     </PostBuildEvent>
@@ -165,6 +166,7 @@ xcopy /y $(SolutionDir)bin\$(Configuration)-$(Platform)\PlaneverbDSP\PlaneverbDS
     </Link>
     <PostBuildEvent>
       <Command>xcopy /y $(SolutionDir)bin\$(Configuration)-$(Platform)\ProjectPlaneverb\ProjectPlaneverb.dll $(SolutionDir)bin\$(Configuration)-$(Platform)\$(ProjectName)
+xcopy /y $(SolutionDir)bin\$(Configuration)-$(Platform)\ProjectPlaneverb\ProjectPlaneverb.pdb $(SolutionDir)bin\$(Configuration)-$(Platform)\$(ProjectName)
 xcopy /y $(SolutionDir)External\dll\$(Platform)\*.dll $(SolutionDir)bin\$(Configuration)-$(Platform)\$(ProjectName)
 xcopy /y $(SolutionDir)bin\$(Configuration)-$(Platform)\PlaneverbDSP\PlaneverbDSP.dll $(SolutionDir)bin\$(Configuration)-$(Platform)\$(ProjectName)</Command>
     </PostBuildEvent>

--- a/PlaneverbSandbox/src/main.cpp
+++ b/PlaneverbSandbox/src/main.cpp
@@ -16,14 +16,14 @@ int main()
 	config.gridBoundaryType = Planeverb::pv_AbsorbingBoundary;
 	config.gridSizeInMeters = Planeverb::vec2(25.f, 25.f);
 	config.tempFileDirectory = ".";
-	config.maxThreadUsage = 2;
+	config.maxThreadUsage = 1;
 	
 	Planeverb::Init(&config);
 	
 	PlaneverbDSP::PlaneverbDSPConfig dspConfig;
 	dspConfig.samplingRate = RATE;
 	dspConfig.useSpatialization = true;
-	dspConfig.dspSmoothingFactor = 5;
+	dspConfig.dspSmoothingFactor = 2;
 	PlaneverbDSP::Init(&dspConfig);
 	
 	AudioCore::Instance().Init();

--- a/ProjectPlaneverb/ProjectPlaneverb.vcxproj
+++ b/ProjectPlaneverb/ProjectPlaneverb.vcxproj
@@ -136,11 +136,11 @@
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(ProjectDir)include; $(ProjectDir)src;</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>PV_BUILD;_WINDLL;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;PV_BUILD;_WINDLL;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <OpenMPSupport>true</OpenMPSupport>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <FloatingPointModel>Fast</FloatingPointModel>
-      <AdditionalOptions>/arch:AVX2 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/arch:AVX2 /Qvec-report:2 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/ProjectPlaneverb/include/PvMathTypes.h
+++ b/ProjectPlaneverb/include/PvMathTypes.h
@@ -1,10 +1,10 @@
 #pragma once
 
+// Enable different bit-depth for floating point numbers
+#define Real float
+
 namespace Planeverb
 {
-	// Enable different bit-depth for floating point numbers
-	using Real = float;
-
 	struct vec3
 	{
 		Real x, y, z;

--- a/ProjectPlaneverb/include/PvTypes.h
+++ b/ProjectPlaneverb/include/PvTypes.h
@@ -63,6 +63,7 @@ namespace Planeverb
 	struct PlaneverbOutput
 	{
 		float occlusion;
+        float wetGain;
 		float rt60;
 		float lowpass;
 		vec2 direction;

--- a/ProjectPlaneverb/include/PvTypes.h
+++ b/ProjectPlaneverb/include/PvTypes.h
@@ -85,19 +85,19 @@ namespace Planeverb
 	const constexpr Real PV_Z_AIR = PV_RHO * PV_C;						// natural impedance of air
 	const constexpr Real PV_INV_Z_AIR = (Real)1.f / PV_Z_AIR;			// inverse impedance for absorbing boundaries
 	const constexpr Real PV_INV_Z_REFLECT = (Real)0.0f;					// inverse impedance for reflecting boundaries
-	const constexpr Real PV_AUDIBLE_THRESHOLD_GAIN = (Real)0.00000316f;	// precalculated -110 dB converted to voltage gain
-	const constexpr Real PV_DRY_GAIN_ANALYSIS_LENGTH = (Real)0.01f;		// length of time to process the initial pulse for occlusion
-	const constexpr Real PV_WET_GAIN_ANALYSIS_LENGTH = (Real)0.076f;	// length of time to process early reflections
-	const constexpr Real PV_INITIAL_IMPULSE_ESTIMATE = (Real)0.015f;	// initial impulse estimate
+	const constexpr Real PV_AUDIBLE_THRESHOLD_GAIN = (Real)0.00000316f;	// precalculated -110 dB converted to linear gain
+    const constexpr Real PV_DRY_DIRECTION_ANALYSIS_LENGTH = (Real)0.001f;// length of time flux of first wavefront (source direction)
+    const constexpr Real PV_DRY_GAIN_ANALYSIS_LENGTH = (Real)0.01f;		// length of time to process the initial pulse for occlusion
+	const constexpr Real PV_WET_GAIN_ANALYSIS_LENGTH = (Real)0.080f;	// length of time to process early reflections
 	const constexpr Real PV_SQRT_2 = (Real)1.4142136f;					// precalculated sqrt(2)
 	const constexpr Real PV_SQRT_3 = (Real)1.7320508f;					// precalculated sqrt(3)
 	const constexpr Real PV_MAX_AUDIBLE_FREQ = (Real)20000.f;			// maximum audible frequency for humans
 	const constexpr Real PV_MIN_AUDIBLE_FREQ = (Real)20.f;				// minimum audible frequency for humans
-	const constexpr Real PV_POINTS_PER_WAVELENGTH = (Real)5.f;			// number of cells per wavelength
+	const constexpr Real PV_POINTS_PER_WAVELENGTH = (Real)4.f;			// number of cells per wavelength
 	const constexpr Real PV_SCHROEDER_OFFSET_S = (Real)0.01f;			// experimentally calculated amount to cut off schroeder tail
-	const constexpr Real PV_DISTANCE_GAIN_THRESHOLD = (Real)0.891251f;	// -1dB converted to voltage gain
+	const constexpr Real PV_DISTANCE_GAIN_THRESHOLD = (Real)0.891251f;	// -1dB converted to linear gain
 	const constexpr Real PV_DELAY_CLOSE_THRESHOLD = (Real)5.f;			// "close enough" delay threshold when analyzing for direction
-	const constexpr Real PV_IMPULSE_RESPONSE_S = PV_SQRT_2 * Real(5.0) / PV_C + Real(0.15);			// number of seconds to collect per impulse response
+	const constexpr Real PV_IMPULSE_RESPONSE_S = PV_SQRT_2 * Real(12.5) / PV_C + Real(0.15);			// number of seconds to collect per impulse response
 	//                                                             ^ should be half of the scene width
 
 	// struct to represent grid cells

--- a/ProjectPlaneverb/include/PvTypes.h
+++ b/ProjectPlaneverb/include/PvTypes.h
@@ -86,7 +86,7 @@ namespace Planeverb
 	const constexpr Real PV_INV_Z_AIR = (Real)1.f / PV_Z_AIR;			// inverse impedance for absorbing boundaries
 	const constexpr Real PV_INV_Z_REFLECT = (Real)0.0f;					// inverse impedance for reflecting boundaries
 	const constexpr Real PV_AUDIBLE_THRESHOLD_GAIN = (Real)0.00000316f;	// precalculated -110 dB converted to linear gain
-    const constexpr Real PV_DRY_DIRECTION_ANALYSIS_LENGTH = (Real)0.001f;// length of time flux of first wavefront (source direction)
+    const constexpr Real PV_DRY_DIRECTION_ANALYSIS_LENGTH = (Real)0.005f;// length of time flux of first wavefront (source direction)
     const constexpr Real PV_DRY_GAIN_ANALYSIS_LENGTH = (Real)0.01f;		// length of time to process the initial pulse for occlusion
 	const constexpr Real PV_WET_GAIN_ANALYSIS_LENGTH = (Real)0.080f;	// length of time to process early reflections
 	const constexpr Real PV_SQRT_2 = (Real)1.4142136f;					// precalculated sqrt(2)

--- a/ProjectPlaneverb/src/DSP/Analyzer.cpp
+++ b/ProjectPlaneverb/src/DSP/Analyzer.cpp
@@ -7,6 +7,8 @@
 #include <cmath>
 #include <iostream>
 #include <utility>
+#include <algorithm>
+#include <cassert>
 
 namespace Planeverb
 {
@@ -43,7 +45,6 @@ namespace Planeverb
 		//delete[] m_mem;
 	}
 
-	// analyze in parallel
 	void Analyzer::AnalyzeResponses(const vec3& listenerPosGiven)
 	{
 		vec2 dim((Real)m_gridX, (Real)m_gridY);
@@ -54,9 +55,8 @@ namespace Planeverb
 		else
 			omp_set_num_threads(m_numThreads);
 
-		const int NUM_TASKS = 5;
-		int gridSize = (int)m_gridX * (int)m_gridY;
-		int gridIterations = gridSize * NUM_TASKS;
+        int gridSize = (int)m_gridX * (int)m_gridY;
+
 		vec3 listenerPos = listenerPosGiven;
 		listenerPos.x += m_grid->GetGridOffset().x;
 		listenerPos.z += m_grid->GetGridOffset().y;
@@ -69,48 +69,25 @@ namespace Planeverb
 
 		// each type of analysis can be done in parallel
 		// each index can be done in parallel
-		#pragma omp parallel for
-		for (int i = 0; i < gridIterations; ++i)
+		
+//#pragma omp parallel for
+		for (int serialIndex = 0; serialIndex < gridSize; ++serialIndex)
 		{
-			// extract analysis type and real index from i
-			unsigned analysisType = i % NUM_TASKS;
-			unsigned index = i / NUM_TASKS;
-
 			// convert index to grid position, to retrieve IR
 			vec2 gridIndex;
 			unsigned gridX, gridY;
-			INDEX_TO_POS(gridX, gridY, index, dim);
+			INDEX_TO_POS(gridX, gridY, serialIndex, dim);
 			gridIndex.x = (Real)gridX;
 			gridIndex.y = (Real)gridY;
 			const Cell* response = m_grid->GetResponse(gridIndex);
 
-			// use IR to analyze
-			switch (analysisType)
-			{
-				case 0:	// analyze for occlusion
-					m_results[index].occlusion = 
-						AnalyzeOcclusion(index, response, listenerPos, m_responseLength);
-					break;
-				case 1:	// analyze for lowpass
-					m_results[index].lowpassIntensity =
-						AnalyzeLowpassIntensity(index, response, listenerPos, m_responseLength);
-					break;
-				case 2:	// analyze for decay time
-					m_results[index].rt60 =
-						AnalyzeDecayTime(index, response, m_responseLength);
-					break;
-				case 3:	// analyze for delay
-					m_delaySamples[index] = AnalyzeDelay(index, response, m_responseLength);
-					break;
-				case 4: // analyze for source direction
-					m_results[index].sourceDirectivity = AnalyzeSourceDirection(index, response, m_responseLength);
-					break;
-			}
+            EncodeResponse(serialIndex, gridIndex, response, listenerPos, m_responseLength);
 		}
 
 		// run a post processing step to find directions based off of delays
 		// can be run in parallel for each grid position
-		#pragma omp parallel for
+		
+//#pragma omp parallel for
 		for (int i = 0; i < gridSize; ++i)
 		{
 			// retrieve IR
@@ -122,7 +99,7 @@ namespace Planeverb
 			const Cell* response = m_grid->GetResponse(gridIndex);
 
 			// analyze for direction
-			m_results[i].direction = AnalyzeDirection(i, response, listenerPos, m_responseLength);
+			m_results[i].direction = EncodeListenerDirection(i, response, listenerPos, m_responseLength);
 		}
 	}
 
@@ -159,246 +136,179 @@ namespace Planeverb
 		return size;
 	}
 
-	Real Analyzer::AnalyzeOcclusion(unsigned index, const Cell * response, const vec3& listenerPos, unsigned numSamples)
-	{
-		// find emitter and listener grid positions
-		int listenerX = (int)(listenerPos.x * (1.f / m_dx));
-		int listenerY = (int)(listenerPos.z * (1.f / m_dx));
-		vec2 dim((Real)m_gridX, (Real)m_gridY);
-		int emitterX, emitterY;
-		INDEX_TO_POS(emitterX, emitterY, index, dim);
+    void Analyzer::EncodeResponse(unsigned serialIndex, vec2 gridIndex, const Cell* response, const vec3& listenerPos, unsigned n)
+    {
+        const int numSamples = (int)n;
 
-		Real Edry = 0;
-		bool found = false;
-		int j = 0;
-		int numIterations = (int)numSamples;
-		// loop until the first audible sample, then continue for DRY_GAIN_ANALYSIS_LENGTH more seconds
-		// sum signal values squared
-		for (; j < numIterations; ++j)
-		{
-			Real next = response[j].pr;
-			if (!found && std::abs(next) > PV_AUDIBLE_THRESHOLD_GAIN)
-			{
-				numIterations = (int)(PV_DRY_GAIN_ANALYSIS_LENGTH * (Real)m_samplingRate) + j;
-				if (numIterations > (int)m_responseLength)
-					numIterations = (int)m_responseLength;
-				found = true;
-			}
-			else
-			{
-				Edry += next * next;
-			}
-		}
+        // 
+        // ONSET DELAY
+        // 
+        int onsetSample = 0;
+        for (; onsetSample < numSamples; ++onsetSample)
+        {
+            Real next = response[onsetSample].pr;
+            if (std::abs(next) > PV_AUDIBLE_THRESHOLD_GAIN)
+            {
+                break;
+            }
+        }
 
-		// retrieve free energy, and divide by Euclidean distance between them
-		Real EfreePr = m_freeGrid->GetEFreePerR(listenerX, listenerY, emitterX, emitterY);
+        if (onsetSample < numSamples)
+        {
+            m_delaySamples[serialIndex] = (Real)onsetSample;
+        }
+        //no onset found, fill infinity and bail, can't encode anything else.
+        else
+        {
+            m_delaySamples[serialIndex] = std::numeric_limits<Real>::max();
+            return;
+        }
 
-		// find output gain
-		Real E = (Edry / EfreePr);
-		Real g = std::sqrt(E);
-		
-		return g;	
-	}
+        // 
+        // DRY PROCESSING: OBSTRUCTION and SOURCE DIRECTION
+        //
+        int directGainSamples = (int)(PV_DRY_GAIN_ANALYSIS_LENGTH * (Real)m_samplingRate);
+        int sourceDirSamples = (int)(PV_DRY_DIRECTION_ANALYSIS_LENGTH * (Real)m_samplingRate);
+        int sourceDirEnd = onsetSample + sourceDirSamples;
+        int directEnd = onsetSample + directGainSamples;
 
-	Real Analyzer::AnalyzeLowpassIntensity(unsigned index, const Cell* response, const vec3& listenerPos, unsigned numSamples)
-	{
-		// get input distance driven by inverse of occlusion
-		Real r = AnalyzeOcclusion(index, response, listenerPos, numSamples);
-		if(r > 0)
-			r = Real(1.0) / r;
+        assert(sourceDirSamples <= directGainSamples && "Code below assumes source directivity is estimated on a shorter interval of time than dry gain.");
 
-		// feed into equation
-		// y = -147 + (18390) / (1 + (x / 12)^0.8 )
-		Real cutoff = (Real)-147.f + ((Real)18390.f) / ((Real)1.f + std::pow(r / (Real)12.f, (Real)0.8f));
+        Real obstructionGain = 0.0f;
+        vec2 radiationDir(0,0);
+        {
+            Real Edry = 0;
 
-		return cutoff;
-	}
+            int j = 0;
+            for (; j < sourceDirEnd; ++j)
+            {
+                const auto& r = response[j];
+                Edry += r.pr * r.pr;
+                radiationDir.x += r.pr * r.vx;
+                radiationDir.y += r.pr * r.vy;
+            }
 
-	Real Analyzer::AnalyzeDecayTime(unsigned index, const Cell * response, unsigned numSamples)
-	{
-		// Version 2
-		{
-			// FIND THE T60 OF A SIGNAL
-			//==========================
-			//
-			// Use backwards Schroeder integration
-			//         ^ inf
-			// I(t) = | (P(t))^2 dt
-			//       v t
-			//
-			// For each point in the signal starting at the end, going backwards until the end of the impulse
-			// the intensity at the point is sum of the signal squared.
-			// Effectively: 
-			//	s[i], i = 0...N-1 is the signal
-			//	EnergyDecayCurve[i] = sum(s[i...N-1]^2)
-			//	EnergyDecayCurveDB[i] = 10*log10(EnergyDecayCurve[i])
-			// Taking the slope of the generated curve will give the T60
-			// slope of I(t), given f = max seconds, the slope is the simple linear regression, as above:
-			//
-			// B = sum((x_i - xbar) * (y_i - ybar), 1, n)
-			//	   ----------------------------------------
-			//		     sum( (x_i - xbar)^2, 1, n )
-			// i = index
-			// x_i = t
-			// xbar = average of x_i
-			// y_i = EnergyDecayCurveDB[i]
-			// ybar = average of y_i
-			// 
-			// To find the T60: 
-			// T60 = -60dB / B
+            for (; j < directEnd; ++j)
+            {
+                const auto& r = response[j];
+                Edry += r.pr * r.pr;
+            }
 
-			// find starting point
-			int startingPoint = 0;
-			Real next = 0.f;
-			Real samplingRate = (Real)m_samplingRate;
-			int numIterations = (int)numSamples;
-			for (int i = 0; i < numIterations; ++i)
-			{
-				next = response[i].pr;
-				if (std::abs(next) > PV_AUDIBLE_THRESHOLD_GAIN)
-				{
-					startingPoint = i + (int)(PV_DRY_GAIN_ANALYSIS_LENGTH * samplingRate);
-					break;
-				}
-			}
+            // Normalize dry energy by free-space energy to obtain geometry-based 
+            // obstruction gain with distance attenuation factored out
+            Real EfreePr = 0.0f;
+            {
+                const int listenerX = (int)(listenerPos.x * (1.f / m_dx));
+                const int listenerY = (int)(listenerPos.z * (1.f / m_dx));
+                const int emitterX = gridIndex.x;
+                const int emitterY = gridIndex.y;
 
-			// perform backwards integration
-			// set up variables
-			int end = numIterations - 1;
-			int count = 0;
-			Real invCount = 1.f;
-			Real nextSquared = 0.f; 
-			
-			Real B = 0.f;
-			Real x_i = 0.f, xbar = 0.f, xterm = 0.f;
-			Real y_i = 0.f, ybar = 0.f, yterm = 0.f;
-			Real numer = 0.f, denom = 0.f;
+                EfreePr = m_freeGrid->GetEFreePerR(listenerX, listenerY, emitterX, emitterY);
+            }
 
-			// end point for when to start keeping track for linear regression
-			int endPoint = end - (int)(PV_SCHROEDER_OFFSET_S * samplingRate);
+            Real E = (Edry / EfreePr);
+            obstructionGain = std::sqrt(E);
 
-			Real energyDecayCurve = 0.f;
-			Real energyDecayCurveDB = 0.f;
-			for (int i = end; i >= startingPoint; --i)
-			{
-				// calculate next schroeder value
-				nextSquared = response[i].pr;
-				energyDecayCurve += nextSquared * nextSquared;
+            // Normalize and negate flux direction to obtain radiated unit vector
+            auto norm = std::sqrt(radiationDir.x*radiationDir.x + radiationDir.y*radiationDir.y);
+            norm = -1.0f / (norm > 0.0f ? norm : 1.0f);
+            radiationDir.x = norm * radiationDir.x;
+            radiationDir.y = norm * radiationDir.y;
+        }
+        
+        m_results[serialIndex].occlusion = obstructionGain;
+        m_results[serialIndex].sourceDirectivity = radiationDir;
 
-				// calculate next schroeder value in dB
-				energyDecayCurveDB = 10.f * std::log10(energyDecayCurve);
+        //
+        // LOW-PASS CUTOFF FREQUENCY
+        //
 
-				// regression math
-				if (i < endPoint)
-				{
-					count++;
+        // get input distance driven by inverse of occlusion. If occlusion is very small, cap out at "lots of occlusion"
+        Real r = 1.0f / std::max(0.001f, obstructionGain);
+        // Find LPF cutoff frequency by feeding into equation: y = -147 + (18390) / (1 + (x / 12)^0.8 )
+        m_results[serialIndex].lowpassIntensity = 
+            (Real)-147.f + ((Real)18390.f) / ((Real)1.f + std::pow(r / (Real)12.f, (Real)0.8f));
 
-					// calculate x
-					x_i = (Real)i / samplingRate;
-					xbar += x_i;
-					
-					// calculate y
-					y_i = energyDecayCurveDB;
-					ybar += y_i;
-				}
-			}
-			
-			xbar = xbar / count;
-			ybar = ybar / count;
+        //
+        // Decay Time
+        //
+        {
+            // FIND THE T60 OF A SIGNAL
+            //==========================
+            //
+            // Use backwards Schroeder integration
+            //         ^ inf
+            // I(t) = | (P(t))^2 dt
+            //       v t
+            //
+            // For each point in the signal starting at the end, going backwards until the end of the impulse
+            // the intensity at the point is sum of the signal squared.
+            // Effectively: 
+            //	s[i], i = 0...N-1 is the signal
+            //	EnergyDecayCurve[i] = sum(s[i...N-1]^2)
+            //	EnergyDecayCurveDB[i] = 10*log10(EnergyDecayCurve[i])
+            // Taking the slope of the generated curve will give the T60
+            // slope of I(t), given f = max seconds, the slope is the simple linear regression, as above:
+            //
+            // B = sum((x_i - xbar) * (y_i - ybar), 1, n)
+            //	   ----------------------------------------
+            //		     sum( (x_i - xbar)^2, 1, n )
+            // i = index
+            // x_i = t
+            // xbar = average of x_i
+            // y_i = EnergyDecayCurveDB[i]
+            // ybar = average of y_i
+            // 
+            // To find the T60: 
+            // T60 = -60dB / B
 
-			energyDecayCurve = 0.f;
-			energyDecayCurveDB = 0.f;
+            int startingPoint = directEnd + 1;
+            // linear regression ignores some fixed bit of tail of energy decay curve which dips towards 0
+            int endPoint = numSamples - (int)(PV_SCHROEDER_OFFSET_S * m_samplingRate);
+            int regressN = endPoint - startingPoint;
+            Real rn = Real(regressN);
 
-			// loop backwards for Schroeder integration
-			for (int i = end; i >= startingPoint; --i)
-			{
-				// calculate next schroeder value
-				nextSquared = response[i].pr;
-				energyDecayCurve += nextSquared * nextSquared;
+            // We regress assuming time-step is 1 and startingPoint is x=0.
+            // The latter offset does not change slope, and time-step adjustment is done at end.
+            Real xmean = (rn - 1.0f) * 0.5f;
+            Real xsum = rn * xmean;
+            
+            // Sum[(x-xmean)^2] = Sum[(i - ((n - 1)/2))^2, {i, 0, n - 1}] = 1/12 n (-1 + n^2)
+            Real denominator = (1.0f / 12.0f) * rn * (rn*rn - 1.0f);
 
-				// calculate next schroeder value in dB
-				energyDecayCurveDB = 10.f * std::log10(energyDecayCurve);
+            // Backward energy integral
+            Real energyDecayCurve = 0.f;
+            Real energyDecayCurveDB = 0.f;
+            Real xysum = 0;
+            Real ysum = 0;
 
-				// regression math
-				if (i < endPoint)
-				{
-					// calculate x
-					x_i = (Real)i / samplingRate;
-					xterm = x_i - xbar;
+            // For tail bit just accumulate energy, no regression
+            for (int i = numSamples - 1; i >= endPoint; --i)
+            {
+                auto p = response[i].pr;
+                energyDecayCurve += p * p;
+            }
 
-					// calculate y
-					y_i = energyDecayCurveDB;
-					yterm = y_i - ybar;
+            for (int i = endPoint-1; i >= startingPoint; --i)
+            {
+                auto p = response[i].pr;
+                energyDecayCurve += p * p;
+                energyDecayCurveDB = 10.f * std::log10(energyDecayCurve);
 
-					// calculate numer
-					numer += (xterm * yterm);
+                Real y_i = energyDecayCurveDB;
+                auto x_i = (i - startingPoint);
+                xysum += y_i * x_i;
+                ysum += y_i;
+            }
 
-					// calculate denom
-					denom += xterm * xterm;
-				}
-			}
-
-			B = numer / denom;
-			Real T60 = -60.f / B;
-			return T60;
-		}
-	}
-
-	//Returns attenuation from source assuming cardiod direcivity
-	vec2 Analyzer::AnalyzeSourceDirection(unsigned index, const Cell* response, unsigned numSamples)
-	{
-		vec2 accum{ 0, 0 };
-		const Cell* responseStart = response;
-		int numIterations = (int)numSamples;
-		bool found = false;
-		for (unsigned i = 0; i < numSamples; ++i)
-		{
-			Real next = response->pr;
-			if (!found && std::abs(next) > PV_AUDIBLE_THRESHOLD_GAIN)
-			{
-				numIterations = (int)(PV_DRY_GAIN_ANALYSIS_LENGTH * (Real)m_samplingRate) + i;
-				if (numIterations > (int)m_responseLength)
-					numIterations = (int)m_responseLength;
-				found = true;
-			}
-			else
-			{
-				accum.x += Real(-1) * response->vx * next;
-				accum.y += Real(-1) * response->vy * next;
-			}
-
-			
-			++response;
-		}
-
-		Real denom = (accum.x * accum.x) + (accum.y * accum.y);
-		if (denom == Real(0)) denom = Real(1);
-		else denom = std::sqrt(denom);
-		vec2 radiationFromSource = { accum.x / denom, accum.y / denom };
-		//Vec RadiationFromSource = Vec(-response->vx * response->pr, -response->vy * response->pr);
-		//Vec ForwardVecForSource;
-
-		//return (1.0f + DotProduct(RaditionFromSource, ForwardVecFromSource)) / 2.0f;
-		return radiationFromSource;
-	}
-
-	Real Analyzer::AnalyzeDelay(unsigned index, const Cell * response, unsigned numSamples)
-	{
-		// find the first audible sample and return it's index
-		int j = 0;
-		int numIterations = (int)numSamples;
-		for (; j < numIterations; ++j)
-		{
-			Real next = response[j].pr;
-			if (std::abs(next) > PV_AUDIBLE_THRESHOLD_GAIN)
-			{
-				return (Real)j;
-			}
-		}
-
-		// case no audible samples, return infinity
-		return std::numeric_limits<Real>::max();
-	}
+            Real ymean = ysum / rn;
+            Real numerator = xysum - ymean * xsum - xmean * ysum + rn * xmean * ymean;
+            
+            Real slopeDBperSample = numerator / denominator;
+            Real slopeDBperSec = slopeDBperSample * m_samplingRate;
+            m_results[serialIndex].rt60 = -60.f / slopeDBperSec;
+        }
+    }
 
 	namespace
 	{
@@ -410,99 +320,96 @@ namespace Planeverb
 		};
 	} // namespace <>
 
-	vec2 Analyzer::AnalyzeDirection(unsigned index, const Cell * response, const vec3& listenerPos, unsigned numSamples)
-	{
-		/* VERSION 2 */
-		{
-			Real loudness = m_results[index].occlusion;
-			vec2 dim((Real)m_gridX, (Real)m_gridY);
-			int nextIndex = index;
-			const constexpr Real maxDelay = std::numeric_limits<Real>::max();
-			Real delay = maxDelay;
-			Real nextDelay = maxDelay;
-			Real samplingRate = (Real)m_samplingRate;
-			Real wavelength = PV_C / (Real)m_resolution;
-			const Real threshold = (Real)0.3f;
-			Real thresholdDist = threshold * wavelength;
+    vec2 Analyzer::EncodeListenerDirection(unsigned index, const Cell * response, const vec3& listenerPos, unsigned numSamples)
+    {
+        Real loudness = m_results[index].occlusion;
+        vec2 dim((Real)m_gridX, (Real)m_gridY);
+        int nextIndex = index;
+        const constexpr Real maxDelay = std::numeric_limits<Real>::max();
+        Real delay = maxDelay;
+        Real nextDelay = maxDelay;
+        Real samplingRate = (Real)m_samplingRate;
+        Real wavelength = PV_C / (Real)m_resolution;
+        const Real threshold = (Real)0.3f;
+        Real thresholdDist = threshold * wavelength;
 
-			// loop while not close to the listener
-			while (delay > PV_DELAY_CLOSE_THRESHOLD && loudness < PV_DISTANCE_GAIN_THRESHOLD)
-			{
-				int r, c;
-				INDEX_TO_POS(r, c, nextIndex, dim);
-				Real nextLoudness = 0.f;
-				Real nextDelay = maxDelay;
+        // loop while not close to the listener
+        while (delay > PV_DELAY_CLOSE_THRESHOLD && loudness < PV_DISTANCE_GAIN_THRESHOLD)
+        {
+            int r, c;
+            INDEX_TO_POS(r, c, nextIndex, dim);
+            Real nextLoudness = 0.f;
+            Real nextDelay = maxDelay;
 
-				// for each neighbor find the neighbor with the smallest delay time
-				for (int i = 0; i < _countof(POSSIBLE_NEIGHBORS); ++i)
-				{
-					int nr = r + POSSIBLE_NEIGHBORS[i].first;
-					int nc = c + POSSIBLE_NEIGHBORS[i].second;
-					if (nr < 0 || nc < 0 || nr >= (int)dim.x || nc >= (int)dim.y)
-						continue;
+            // for each neighbor find the neighbor with the smallest delay time
+            for (int i = 0; i < _countof(POSSIBLE_NEIGHBORS); ++i)
+            {
+                int nr = r + POSSIBLE_NEIGHBORS[i].first;
+                int nc = c + POSSIBLE_NEIGHBORS[i].second;
+                if (nr < 0 || nc < 0 || nr >= (int)dim.x || nc >= (int)dim.y)
+                    continue;
 
-					int newPosIndex = INDEX(nr, nc, dim);
-					auto& result = m_results[newPosIndex];
-					Real delay = m_delaySamples[newPosIndex];
-					if ((unsigned)delay == numSamples || result.occlusion == 0.f)
-						continue;
-					else if (delay < nextDelay && result.occlusion > 0.f)
-					{
-						nextLoudness = result.occlusion;
-						nextIndex = newPosIndex;
-						nextDelay = delay;
-					}
-				}
+                int newPosIndex = INDEX(nr, nc, dim);
+                auto& result = m_results[newPosIndex];
+                Real delay = m_delaySamples[newPosIndex];
+                if ((unsigned)delay == numSamples || result.occlusion == 0.f)
+                    continue;
+                else if (delay < nextDelay && result.occlusion > 0.f)
+                {
+                    nextLoudness = result.occlusion;
+                    nextIndex = newPosIndex;
+                    nextDelay = delay;
+                }
+            }
 
-				// case couldn't find a valid neighbor
-				if (nextDelay == std::numeric_limits<Real>::max() || nextDelay >= delay)
-				{
-					break;
-				}
+            // case couldn't find a valid neighbor
+            if (nextDelay == std::numeric_limits<Real>::max() || nextDelay >= delay)
+            {
+                break;
+            }
 
-				delay = nextDelay;
-				loudness = nextLoudness;
+            delay = nextDelay;
+            loudness = nextLoudness;
 
-				// line of sight check
-				Real geodesicDist = PV_C * nextDelay / samplingRate;
-				int r2, c2;
-				INDEX_TO_POS(r2, c2, nextIndex, dim);
+            // line of sight check
+            Real geodesicDist = PV_C * nextDelay / samplingRate;
+            int r2, c2;
+            INDEX_TO_POS(r2, c2, nextIndex, dim);
 
-				// convert grid position to worldspace
-				Real ex = (Real)r2 * m_dx;
-				Real ey = (Real)c2 * m_dx;
+            // convert grid position to worldspace
+            Real ex = (Real)r2 * m_dx;
+            Real ey = (Real)c2 * m_dx;
 
-				// find vector between and normalize
-				vec2 temp(ex - listenerPos.x, ey - listenerPos.z);
-				Real euclideanDist = (temp.x * temp.x) + (temp.y * temp.y);;
-				euclideanDist = std::sqrt(euclideanDist);
-				Real distCheck = std::abs(geodesicDist - euclideanDist);
-				bool isInLineOfSight = distCheck < thresholdDist;
-				if (isInLineOfSight)
-					break;
-			}
+            // find vector between and normalize
+            vec2 temp(ex - listenerPos.x, ey - listenerPos.z);
+            Real euclideanDist = (temp.x * temp.x) + (temp.y * temp.y);;
+            euclideanDist = std::sqrt(euclideanDist);
+            Real distCheck = std::abs(geodesicDist - euclideanDist);
+            bool isInLineOfSight = distCheck < thresholdDist;
+            if (isInLineOfSight)
+                break;
+        }
 
-			// find direction vector between nextIndex and listener position
+        // find direction vector between nextIndex and listener position
 
-			// convert 1D index to 2D grid position
-			int r, c;
-			INDEX_TO_POS(r, c, nextIndex, dim);
+        // convert 1D index to 2D grid position
+        int r, c;
+        INDEX_TO_POS(r, c, nextIndex, dim);
 
-			// convert grid position to worldspace
-			Real ex = (Real)r * m_dx;
-			Real ey = (Real)c * m_dx;
+        // convert grid position to worldspace
+        Real ex = (Real)r * m_dx;
+        Real ey = (Real)c * m_dx;
 
-			// find vector between and normalize
-			vec2 output(ex - listenerPos.x, ey - listenerPos.z);
-			Real length = (output.x * output.x) + (output.y * output.y);
-			if (length != 0.f)
-			{
-				length = std::sqrt(length);
-				output.x /= length;
-				output.y /= length;
-			}
+        // find vector between and normalize
+        vec2 output(ex - listenerPos.x, ey - listenerPos.z);
+        Real length = (output.x * output.x) + (output.y * output.y);
+        if (length != 0.f)
+        {
+            length = std::sqrt(length);
+            output.x /= length;
+            output.y /= length;
+        }
 
-			return output;
-		}
-	}
+        return output;
+    }
 } // namespace Planeverb

--- a/ProjectPlaneverb/src/DSP/Analyzer.h
+++ b/ProjectPlaneverb/src/DSP/Analyzer.h
@@ -13,6 +13,7 @@ namespace Planeverb
 	struct AnalyzerResult
 	{
 		Real occlusion;
+        Real wetGain;
 		Real rt60;
 		Real lowpassIntensity;
 		vec2 direction;

--- a/ProjectPlaneverb/src/DSP/Analyzer.h
+++ b/ProjectPlaneverb/src/DSP/Analyzer.h
@@ -26,17 +26,13 @@ namespace Planeverb
 		Analyzer(Grid* grid, FreeGrid* freeGrid, char* mem);
 		~Analyzer();
 
-		void AnalyzeResponses(const vec3& listenerPos);
+        void AnalyzeResponses(const vec3& listenerPos);
 		const AnalyzerResult* GetResponseResult(const vec3& emitterPos) const;
 		static unsigned GetMemoryRequirement(const struct PlaneverbConfig* config);
 
 	private:
-		Real AnalyzeOcclusion(unsigned index, const Cell* response, const vec3& listenerPos, unsigned numSamples);
-		Real AnalyzeLowpassIntensity(unsigned index, const Cell* response, const vec3& listenerPos, unsigned numSamples);
-		Real AnalyzeDecayTime(unsigned index, const Cell* response, unsigned numSamples);
-		Real AnalyzeDelay(unsigned index, const Cell* response, unsigned numSamples);
-		vec2 AnalyzeDirection(unsigned index, const Cell* response, const vec3& listenerPos, unsigned numSamples);
-		vec2 AnalyzeSourceDirection(unsigned index, const Cell* response, unsigned numSamples);
+        void EncodeResponse(unsigned serialIndex, vec2 gridIndex, const Cell* response, const vec3& listenerPos, unsigned numSamples);
+		vec2 EncodeListenerDirection(unsigned index, const Cell* response, const vec3& listenerPos, unsigned numSamples);
 		char* m_mem;				// pool of memory
 		AnalyzerResult* m_results;	// 2D grid using 1D memory, grid of results
 		Real* m_delaySamples;		// grid of delay, to be used to find direction

--- a/ProjectPlaneverb/src/FDTD/FDTD.cpp
+++ b/ProjectPlaneverb/src/FDTD/FDTD.cpp
@@ -83,7 +83,7 @@ namespace Planeverb
 	}
 	
 	// process FDTD
-	void Grid::GenerateResponseCPU(const vec3 & listener)
+	void Grid::GenerateResponseCPU(const vec3 &listener)
 	{
 		// determine pressure and velocity update constants
 		const Real Courant = m_dt / m_dx;
@@ -110,22 +110,23 @@ namespace Planeverb
 		// RESET all pressure and velocity, but not B fields (can't use memset)
 		{
 			Cell* resetPtr = m_grid;
-			for (int i = 0; i < loopSize; ++i)
+            const int N = loopSize;
+			for (int i = 0; i < N; ++i, ++resetPtr)
 			{
 				resetPtr->pr = 0.f;
 				resetPtr->vx = 0.f;
 				resetPtr->vy = 0.f;
-				++resetPtr;
 			}
 		}
 
-		// process FDTD update for 1 IR
+		// Time-stepped FDTD simulation
 		for (int t = 0; t < responseLength; ++t)
 		{
 			// process pressure grid
 			{
-				#pragma omp parallel for
-				for (int i = 0; i < loopSize; ++i)
+                const int N = loopSize;
+//#pragma omp parallel for
+                for (int i = 0; i < N; ++i)
 				{
 					vec2* normal = &(m_boundaries[i].normal);
 					int normalInd = i + (int)normal->y * (gridy + 1) + (int)normal->x;	// [i + n.x, j + n.y]
@@ -145,7 +146,7 @@ namespace Planeverb
 			// process x component of particle velocity
 			{
 				// eq to for(1 to sizex) for(0 to sizey)
-				#pragma omp parallel for
+//#pragma omp parallel for
 				for (int i = gridy + 1; i < loopSize; ++i)
 				{
 					vec2* normal = &(m_boundaries[i].normal);
@@ -164,7 +165,7 @@ namespace Planeverb
 			// process y component of particle velocity
 			{
 				// eq to for(0 to sizex) for(1 to sizey)
-				#pragma omp parallel for
+//#pragma omp parallel for
 				for (int i = 1; i < loopSize; ++i)
 				{
 					vec2 normal = (m_boundaries[i].normal);
@@ -182,7 +183,7 @@ namespace Planeverb
 
 			// process ABC top/bottom
 			{
-				#pragma omp parallel for
+//#pragma omp parallel for
 				for (int i = 0; i < gridy; ++i)
 				{
 					int index1 = i;
@@ -195,7 +196,7 @@ namespace Planeverb
 
 			// process ABC left/right
 			{
-				#pragma omp parallel for
+//#pragma omp parallel for
 				for (int i = 0; i < gridx; ++i)
 				{
 					int index1 = i * (gridy + 1);
@@ -208,7 +209,7 @@ namespace Planeverb
 
 			// add results to the response cube
 			{
-				#pragma omp parallel for
+//#pragma omp parallel for
 				for (int i = 0; i < loopSize; ++i)
 				{
 					m_pulseResponse[i][t] = m_grid[i];

--- a/ProjectPlaneverb/src/FDTD/FDTD.cpp
+++ b/ProjectPlaneverb/src/FDTD/FDTD.cpp
@@ -48,6 +48,7 @@ namespace Planeverb
 
 		// copy over values
 		out.occlusion = (float)result->occlusion;
+        out.wetGain = (float)result->wetGain;
 		out.lowpass = (float)result->lowpassIntensity;
 		out.rt60 = (float)result->rt60;
 		out.direction = result->direction;

--- a/ProjectPlaneverb/src/FDTD/FreeGrid.cpp
+++ b/ProjectPlaneverb/src/FDTD/FreeGrid.cpp
@@ -86,7 +86,7 @@ namespace Planeverb
 			return efree;
 		}
 
-		// divide free energy by distance
+		// 2D propagation: energy decays as 1/r
 		return efree / r;
 	}
 

--- a/ProjectPlaneverb/src/FDTD/FreeGrid.cpp
+++ b/ProjectPlaneverb/src/FDTD/FreeGrid.cpp
@@ -1,21 +1,11 @@
 #include <FDTD\FreeGrid.h>
 #include <PvDefinitions.h>
 
-/*
-	Free Grid file spec:
-	File Name: .free_responseX<meters.x>X<meters.y>X<scale>
-		example: .free_responseX10X10X0.1
-
-	File Contents:
-		<EFree of the grid>
-
-	That's it. Just one value.
-*/
-
 namespace Planeverb
 { 
 	FreeGrid::FreeGrid(const PlaneverbConfig * config, char* mem) : 
 		m_grid(nullptr),
+        m_dx(0),
 		m_EFree(0.f)
 	{
 		// make a new temporary grid
@@ -31,31 +21,9 @@ namespace Planeverb
 			throw pv_NotEnoughMemory;
 		}
 
-		// construct file name
-		m_dx = m_grid->GetDX();
-		std::string fileString(config->tempFileDirectory);
-		fileString += "\\free_responseX";
-		fileString += std::to_string(config->gridSizeInMeters.x);
-		fileString += "X";
-		fileString += std::to_string(config->gridSizeInMeters.y);
-		fileString += "X";
-		fileString += std::to_string(config->gridResolution);
-		fileString += ".dat";
-
-		// try to open free energy file
-		std::ifstream fileForRead(fileString.c_str());
-
-		// case no existing file, generate it
-		if (!fileForRead.is_open())
-		{
-			GenerateFile(config, fileString);
-		}
-		// case existing file, use it
-		else
-		{
-			ParseFile(config, fileForRead);
-		}
-
+        m_dx = m_grid->GetDX();
+        m_EFree = SimulateFreeFieldEnergy(config);
+		
 		// delete the temporary grid
 		delete m_grid;
 		m_grid = nullptr;
@@ -90,31 +58,23 @@ namespace Planeverb
 		return efree / r;
 	}
 
+    Real FreeGrid::GetEnergyAtOneMeter() const
+    {
+        return m_EFree;
+    }
+
 	unsigned FreeGrid::GetMemoryRequirement(const PlaneverbConfig * config)
 	{
 		return 0;
 	}
 
-	void FreeGrid::ParseFile(const PlaneverbConfig* config, std::ifstream & file)
-	{
-		// retrieve the free energy
-		file >> m_EFree;
-	}
-
-	void FreeGrid::GenerateFile(const PlaneverbConfig* config, const std::string & fileName)
+	Real FreeGrid::SimulateFreeFieldEnergy(const PlaneverbConfig* config)
 	{
 		vec2 gridScale = m_grid->GetGridSize();
 		int gridx = (int)gridScale.x;
 		int gridy = (int)gridScale.y;
 		int sizePerGrid = gridx * gridy;
 		
-		// open a new file for write, throw if can't create a file in the given directory
-		std::fstream of(fileName.c_str(), std::ios_base::out);
-		if (!of.is_open())
-		{
-			throw pv_InvalidConfig;
-		}
-
 		int listenerX = gridx / 2;
 		int listenerY = gridy / 2;
 		int emitterX = listenerX + (int)(1.f / m_dx);
@@ -123,17 +83,20 @@ namespace Planeverb
 		// generate a set of IRs in the grid, calculate the free energy
 		m_grid->GenerateResponse(vec3(listenerX * m_dx, 0, listenerY * m_dx));
 		const Cell* response = m_grid->GetResponse(vec2((float)emitterX, (float)emitterY));
-		m_EFree = CalculateEFree(response, m_grid->GetResponseSize(), 
-			listenerX, listenerY, (int)m_grid->GetSamplingRate());
+        Real freeFieldEnergy = CalculateEFree(response, m_grid->GetResponseSize(), (int)m_grid->GetSamplingRate());
 
-		// add data to the file
-		of << m_EFree;
+        // discrete distance on grid
+        const Real r = Real(emitterX - listenerX) * m_dx;
+        // Normalize to exactly 1m assuming 1/r energy attenuation
+        freeFieldEnergy *= r;
+
+        return freeFieldEnergy;
 	}
 
-	Real FreeGrid::CalculateEFree(const Cell * response, int responseLength,
-		int listenerX, int listenerY, int samplingRate) const
+	Real FreeGrid::CalculateEFree(const Cell * response, int responseLength, int samplingRate) const
 	{
-		int numSamples = (int)((PV_DRY_GAIN_ANALYSIS_LENGTH) * ((Real)samplingRate)) + (int)(((Real)1.f / PV_C) * (Real)samplingRate);
+		// Dry duration, plus delay to get 1m away
+        int numSamples = (int)((PV_DRY_GAIN_ANALYSIS_LENGTH) * ((Real)samplingRate)) + (int)(((Real)1.f / PV_C) * (Real)samplingRate);
 		PV_ASSERT(numSamples < responseLength);
 		Real efree = 0.f;
 

--- a/ProjectPlaneverb/src/FDTD/FreeGrid.h
+++ b/ProjectPlaneverb/src/FDTD/FreeGrid.h
@@ -1,9 +1,6 @@
 #pragma once
 #include <PvTypes.h>
-#include "Grid.h"	// Cell
-
-#include <string>	// string
-#include <fstream>	// ifstream
+#include "Grid.h"
 
 namespace Planeverb
 {
@@ -14,15 +11,12 @@ namespace Planeverb
 		~FreeGrid();
 
 		Real GetEFreePerR(int listenerIndX, int listenerIndY, int emitterIndX, int emitterIndY);
-		static unsigned GetMemoryRequirement(const struct PlaneverbConfig* config);
+        Real GetEnergyAtOneMeter() const;
+        static unsigned GetMemoryRequirement(const struct PlaneverbConfig* config);
 
 	private:
-
-		void ParseFile(const PlaneverbConfig* config, std::ifstream& file);
-		void GenerateFile(const PlaneverbConfig* config, const std::string& fileName);
-
-		Real CalculateEFree(const Cell* response, int responseLength,
-			int lX, int lY, int samplingRate) const;
+		Real SimulateFreeFieldEnergy(const PlaneverbConfig* config);
+		Real CalculateEFree(const Cell* response, int responseLength, int samplingRate) const;
 
 		Grid* m_grid;
 		Real m_dx;

--- a/ProjectPlaneverb/src/FDTD/Grid.cpp
+++ b/ProjectPlaneverb/src/FDTD/Grid.cpp
@@ -13,7 +13,7 @@ namespace Planeverb
 		{
             const float maxFreq = Real(config->gridResolution);
             const float pi = std::acos(-1);
-            float sigma = 1.0f / (0.75 * pi * maxFreq);
+            float sigma = 1.0f / (0.5 * pi * maxFreq);
 
 			const float delay = 2*sigma;
             const float dt = 1.0f / samplingRate;

--- a/ProjectPlaneverb/src/FDTD/Grid.cpp
+++ b/ProjectPlaneverb/src/FDTD/Grid.cpp
@@ -9,17 +9,18 @@ namespace Planeverb
 	namespace
 	{
 		// Fill a given array with a precomputed Gaussian pulse
-		void GaussianPulse(Real* out, unsigned numSamples, Real dt = 0)
+		void GaussianPulse(const PlaneverbConfig* config, float samplingRate, Real* out, unsigned numSamples)
 		{
-			// using the formula y = e^(-(t-20)^2 / 100))
-			// use the formula G(t) = e^(-(t-5s)^2 / s^2), s = 10dt
-			const Real delay = (Real)20.f;
-			const Real sigma = (Real)10.f;
-			//const Real sigma = Real(10.0) * dt;
-			//const Real delay = Real(5.0) * sigma;
-			for (unsigned i = 0; i < numSamples; ++i)
+            const float maxFreq = Real(config->gridResolution);
+            const float pi = std::acos(-1);
+            float sigma = 1.0f / (0.75 * pi * maxFreq);
+
+			const float delay = 2*sigma;
+            const float dt = 1.0f / samplingRate;
+
+            for (unsigned i = 0; i < numSamples; ++i)
 			{
-				Real t = (Real)i;
+				Real t = (Real)i * dt;
 				Real val = std::exp(-(t - delay) * (t - delay) / (sigma * sigma));
 				*out++ = val;
 			}
@@ -125,7 +126,7 @@ namespace Planeverb
 		}
 		
 		// precompute Gaussian pulse
-		GaussianPulse(m_pulse, m_responseLength);
+		GaussianPulse(config, m_samplingRate, m_pulse, m_responseLength);
 	}
 
 	Grid::~Grid()
@@ -362,7 +363,7 @@ namespace Planeverb
 	{
 		Real minWavelength = PV_C / (Real)resolution;
 		dx = minWavelength / PV_POINTS_PER_WAVELENGTH;
-		dt = dx / (PV_C * 2.25);
+		dt = dx / (PV_C * Real(2.25));
 		samplingRate = (unsigned)(Real(1.0) / dt);
 	}
 } // namespace Planeverb


### PR DESCRIPTION
- Performance optimizations. 25x25m domain at 275Hz runs on single core runs in ~150ms.
- OpenMP switched off. 
- Gaussian pulse cleanup, made as sharp as possible.
- Reduced PPW to 4 points per wavelength from 5 earlier. 
- [main optimization] Combined all encoder functions into one. Deeply optimized linear regression for RT60.
- Added a proper encoded wet gain. 
- Removed file caching of free field attenuation - rather than stale-file issues, we spend 100ms extra during loading each time, fair trade
- UI beautification for final captures: bigger font, brighter colors